### PR TITLE
Fix for snippets that potentially come across as Lists

### DIFF
--- a/plugin/snipMate.vim
+++ b/plugin/snipMate.vim
@@ -107,13 +107,17 @@ endf
 
 " Check if word under cursor is snippet trigger; if it isn't, try checking if
 " the text after non-word characters is (e.g. check for "foo" in "bar.foo")
-fun s:GetSnippet(word, scope)
+fun! s:GetSnippet(word, scope)
 	let word = a:word | let snippet = ''
 	while snippet == ''
 		let snippetD = get(snipMate#GetSnippets([a:scope], word),word, {})
 		if !empty(snippetD)
 			let s = s:ChooseSnippet(snippetD)
-			let snippet = join(s, "\n")
+			if type(s) == type([])
+				let snippet = join(s, "\n")
+			else
+				let snippet = s
+			end
 			if snippet == '' | break | endif
 		else
 			if match(word, '\W') == -1 | break | endif


### PR DESCRIPTION
I was having an issue with this version of snipMate where snippets from ChooseSnippet sometimes came across as Lists rather than Strings. I believe this patch should ensure that problem won't occur, but knowing little about VIM script I'm not sure if this is the best place/approach to do this. Also I changed the function to always be redefined on load, since it was hard to test changes otherwise. Look it over and let me know what you think.
