### PR TITLE
Generic django and css snippets

### DIFF
--- a/snippets/css.snippets
+++ b/snippets/css.snippets
@@ -1,3 +1,7 @@
+snippet .
+	${1} {
+		${2}
+	}
 snippet !
 	 !important
 snippet bdi:m+

--- a/snippets/htmldjango.snippets
+++ b/snippets/htmldjango.snippets
@@ -1,3 +1,14 @@
+# Generic tags
+
+snippet %
+	{% ${1} %}${2}
+snippet %%
+	{% ${1:tag_name} %}
+	${2}
+	{% end$1 %}
+snippet {
+	{{ ${1} }}${2}
+
 # Template Tags
 
 snippet autoescape


### PR DESCRIPTION
Hi,

In original snipmate there were some really generic snippets for css and django - the dot snippet in css to create curly braces for a class/id is a real time-saver :) same goes for {, %, %% django snippets that expand into django template variable or generic tag. I've search the repo history to find any mentions about rationale of removing them and I couldn't find anything, so I hope my pull request isn't spamming ;)
