### PR TITLE
escaping glob search

### DIFF
--- a/autoload/snipMate.vim
+++ b/autoload/snipMate.vim
@@ -538,18 +538,12 @@ endf
 
 " don't ask me wy searching for trigger { is soo slow.
 fun! s:Glob(dir,  file)
-	let f = s:EscapeGlob(a:dir.a:file)
+	let f = a:dir.a:file
 	if a:dir =~ '\*' || isdirectory(a:dir)
-		return split(glob(f),"\n")
+		return split(glob(escape(f,"{}")),"\n")
 	else
 		return filereadable(f) ? [f] : []
 	endif
-endf
-
-fun! s:EscapeGlob(file)
-	let f = substitute(a:file,"{","\\\\{",'')
-	let f = substitute(f,"}","\\\\}",'')
-	return f
 endf
 
 " returns dict of


### PR DESCRIPTION
I preferred to do a pull request because, frankly, I'm not sure you're going to like this. By the way, I'm sure we can find another solution in the case this one isn't fine with you. So, the problem first: consider the following example (\* for cursor position):

``` ruby
map {|e| e }.sort*
```

Now, I have a sort snippet for ruby file and it normally works fine but, in cases like the above mentioned, it presents you an error like the following:

``` viml
E219: Missing {.
Error detected while processing function TriggerSnippet..<SNR>35_GetSnippet..funcref#Call..snipMate#GetSnippets..funcref#Call..snipMate#DefaultPool..snipMate#GetSnippetFi
les..<SNR>66_Glob:
```

Well, the e219 error is quite clear about the problem. I'v solved with a little function. Hope it helps!
