### PR TITLE
Support for autocomplpop.vim

### DIFF
--- a/plugin/snipMate.vim
+++ b/plugin/snipMate.vim
@@ -225,4 +225,17 @@ fun! ShowAvailableSnips()
 	call complete(col, matches)
 	return ''
 endf
+
+" For autocomplpop
+fun! GetSnipsInCurrentScope() 
+  let snips = {} 
+  for scope in [bufnr('%')] + split(&ft, '\.') + ['_'] 
+    call extend(snips, get(s:snippets, scope, {}), 'keep') 
+    call extend(snips, get(s:multi_snips, scope, {}), 'keep') 
+  endfor 
+  return snips 
+endf 
+
+
+
 " vim:noet:sw=4:ts=4:ft=vim


### PR DESCRIPTION
Hi,

There is a Vim plugin called autocomplpop.
Which is very useful to popup complete menu automatically.
And it can work with vim-snipmate by add a function into it.
This is mentioned in the [document of autocomplpop](https://bitbucket.org/ns9tks/vim-autocomplpop/src/13fe3d806464/doc/acp.txt).

So I made to help adding autocomplpop support into vim-snipmate.
Hope this will be help.
