### PR TITLE
Fixing bug caused by calling deprecated function

### DIFF
--- a/autoload/snipMate.vim
+++ b/autoload/snipMate.vim
@@ -235,7 +235,7 @@ fun! snipMate#jumpTabStop(backwards)
 	if s:curPos == s:snipLen
 		let sMode = s:endCol == g:snipPos[s:curPos-1][1]+g:snipPos[s:curPos-1][2]
 		call s:RemoveSnippet()
-		return sMode ? "\<tab>" : TriggerSnippet()
+		return sMode ? "\<tab>" : snipMate#TriggerSnippet()
 	endif
 
 	call cursor(g:snipPos[s:curPos][0], g:snipPos[s:curPos][1])


### PR DESCRIPTION
Pressing tab more times than defined in snippet caused printing this:

```
Error detected while processing function snipMate#TriggerSnippet..snipMate#jumpTabStop..TriggerSnippet:
line    1:
replace TriggerSnippet by snipMate#TriggerSnippet, please!
Press ENTER or type command to continue
[]
Press ENTER or type command to continue
```

It was so annoying that I fixed it.
Hope it helps you, guys!
