### PR TITLE
Adding support for html/eruby-rails snippets in eruby (*.html.erb) files.

### DIFF
--- a/autoload/snipMate.vim
+++ b/autoload/snipMate.vim
@@ -16,6 +16,7 @@ let s:snipMate['scope_aliases'] = get(s:snipMate,'scope_aliases',
 	  \ ,'php': 'php,html,javascript'
 	  \ ,'ur': 'html,javascript'
 	  \ ,'mxml': 'actionscript'
+	  \ ,'eruby': 'eruby-rails,html'
 	  \ } )
 
 fun! Filename(...)


### PR DESCRIPTION
Adding support for html/eruby-rails snippets in eruby (*.html.erb) files. I don't know if this is worthy of a pull but thought I'd suggest it as I'm sure a lot of textmate converts would enjoy it. Thanks to gmaccarone for his help on this.
