### PR TITLE
Highlight the snippet trigger names in the .snippets files

### DIFF
--- a/syntax/snippets.vim
+++ b/syntax/snippets.vim
@@ -5,11 +5,12 @@ syn match placeHolder '\${\d\+\(:.\{-}\)\=}' contains=snipCommand
 syn match tabStop '\$\d\+'
 syn match snipEscape '\\\\\|\\`'
 syn match snipCommand '\%(\\\@<!\%(\\\\\)*\)\@<=`.\{-}\%(\\\@<!\%(\\\\\)*\)\@<=`'
-syn match snippet '^snippet.*' transparent contains=multiSnipText,snipKeyword
+syn match snippet '^snippet.*' contains=multiSnipText,snipKeyword
 syn match multiSnipText '\S\+ \zs.*' contained
 syn match snipKeyword '^snippet'me=s+8 contained
 syn match snipError "^[^#s\t].*$"
 
+hi link snippet       Identifier
 hi link snipComment   Comment
 hi link multiSnipText String
 hi link snipKeyword   Keyword


### PR DESCRIPTION
The `.snippets` syntax file highlights the keyword "snippet" and the multi-snip text, but not the actual snippet name. This means it's easy to see at a glance where a snippet starts, but not easy to pick out the snippet names (it's the same colour as the replacement text). This change fixes that by highlighting the name as an Identifier.
