### PR TITLE
Exclude cs filetype from default c-derivative mappings in favor of C#.

### DIFF
--- a/autoload/snipMate.vim
+++ b/autoload/snipMate.vim
@@ -10,13 +10,12 @@ catch /.*/
 	echoe "you're missing tlib. See install instructions at ".expand('<sfile>:h:h').'/README.rst'
 endtry
 
-" if filetype is objc, cpp, or cs also append snippets from scope 'c'
+" if filetype is objc or cpp also append snippets from scope 'c'
 " you can add multiple by separating scopes by ',', see s:AddScopeAliases
 " TODO add documentation to doc/*
 let s:snipMate['scope_aliases'] = get(s:snipMate,'scope_aliases',
 	  \ {'objc' :'c'
 	  \ ,'cpp': 'c'
-	  \ ,'cs':'c'
 	  \ ,'xhtml': 'html'
 	  \ ,'html': 'javascript'
 	  \ ,'php': 'php,html,javascript'


### PR DESCRIPTION
Per default, cs filetype is mapped to c. That's been for ages now. However. nowadays it's fairly reasonable to say that C# is a distinct and different language as opposed to a plain C-derivative. With the popularity of Mono, Unity and the C# scripting services the number of active VIM users editing / working on C# files is growing. I'm one of those.

I think it's pretty much OK to exclude the default cs filetype mapping in favor of C# and a custom, distinct `cs.snippets` file. As for the latter, I made a [contribution to snipmate-snippets](https://github.com/honza/snipmate-snippets/pull/66) with a default `cs.snippets` file as well.
