### PR TITLE
fix for python dots

### DIFF
--- a/after/plugin/snipMate.vim
+++ b/after/plugin/snipMate.vim
@@ -18,6 +18,10 @@ if !exists('g:snips_trigger_key_backwards')
   let g:snips_trigger_key_backwards = '<s-' . substitute(g:snips_trigger_key, '[<>]', '', 'g')
 endif
 
+if !exists('g:snipMateAllowMatchingDot')
+	let g:snipMateAllowMatchingDot = 1
+endif
+
 exec 'ino <silent> ' . g:snips_trigger_key . ' <c-g>u<c-r>=snipMate#TriggerSnippet()<cr>'
 exec 'snor <silent> ' . g:snips_trigger_key . ' <esc>i<right><c-r>=snipMate#TriggerSnippet()<cr>'
 exec 'ino <silent> ' . g:snips_trigger_key_backwards . '> <c-r>=snipMate#BackwardsSnippet()<cr>'

--- a/autoload/snipMate.vim
+++ b/autoload/snipMate.vim
@@ -719,9 +719,13 @@ endf
 " used by both: completion and insert snippet
 fun! snipMate#GetSnippetsForWordBelowCursor(word, suffix, break_on_first_match)
 	" Setup lookups: '1.2.3' becomes [1.2.3] + [3, 2.3]
-	let parts = split(a:word, '\W\zs')
-	if len(parts) > 2
-		let parts = parts[-2:] " max 2 additional items, this might become a setting
+	if g:snipMateAllowMatchingDot
+		let parts = split(a:word, '\W\zs')
+		if len(parts) > 2
+			let parts = parts[-2:] " max 2 additional items, this might become a setting
+		endif
+	else
+		let parts = [a:word]
 	endif
 	let lookups = [a:word.a:suffix]
 	let lookup = ''
@@ -732,9 +736,11 @@ fun! snipMate#GetSnippetsForWordBelowCursor(word, suffix, break_on_first_match)
 		endif
 	endfor
 
-	" allow matching '.'
-	if a:word =~ '\.$'
-		call add(lookups, '.'.a:suffix)
+	if g:snipMateAllowMatchingDot
+		" allow matching '.'
+		if a:word =~ '\.$'
+			call add(lookups, '.'.a:suffix)
+		endif
 	endif
 
 	call filter(lookups, 'v:val != ""')


### PR DESCRIPTION
I fixed something concerning dots in python.

Since this was a deeper issue with code and I wasn't always shure what I exactly did :-) please read it.
In the end it's just a new option, which produces by default the same behaviour as your script.

let g:snipMateAllowMatchingDot = 0
Dots can still be expanded, but only if they are alone. Not in cases like "self."
In such cases you rather want autocompletion (with supertab), than another self, which produces "selfself."

https://github.com/garbas/vim-snipmate/issues/65
