### PR TITLE
Adding c snippets to cuda files.

### DIFF
--- a/autoload/snipMate.vim
+++ b/autoload/snipMate.vim
@@ -24,6 +24,7 @@ let s:c['scope_aliases'] = get(s:c,'scope_aliases',
 	  \ {'objc' :'c'
 	  \ ,'cpp': 'c'
 	  \ ,'cs':'c'
+	  \ ,'cu':'c'
 	  \ ,'xhtml': 'html'
 	  \ ,'html': 'javascript'
 	  \ ,'php': 'php,html,javascript'


### PR DESCRIPTION
Could be great to add the C snippets to the CUDA files,
because CUDA is a C-extension language.
