### PR TITLE
Work around vim's glob() function erroneously returning non-existing files

### DIFF
--- a/autoload/snipMate.vim
+++ b/autoload/snipMate.vim
@@ -565,7 +565,14 @@ endf
 fun! s:Glob(dir,  file)
 	let f = a:dir.a:file
 	if a:dir =~ '\*' || isdirectory(a:dir)
-		return split(glob(escape(f,"{}")),"\n")
+		" vim's glob() is somewhat unreliable since it uses the
+		" user's current shell which may accept different patterns
+		" (POSIX vs. zsh vs. bash vs. ...). On my system, that
+		" leads to glob() sometimes returning files that don't
+		" exist, so filter the returned list to make sure that the
+		" files really exist in the filesystem.
+		let res = glob(escape(f,"{}"), 0, 1)
+		return filter(res, 'filereadable(v:val)')
 	else
 		return filereadable(f) ? [f] : []
 	endif


### PR DESCRIPTION
Look at the following, somewhat common, LaTeX code fragment:

``` latex
\begin{someEnvironment}
    % Some neat formulas
\end{so
```

I'm using [SuperTab](https://github.com/ervandew/supertab) and when I try to complete the last line, I get the following error:

```
Error detected while processing function snipMate#TriggerSnippet..<SNR>66_ChooseSnippet..funcref#Call:                                      
line   47:
E484: Can't open file /home/me/.vim/snippets/tex/end{so.snippet
```

Obviously, /home/me/.vim/snippets/tex/end{so.snippet doesn't exist, so why is SnipMate trying to open it? I narrowed this down to the Glob() function in autoload/snipMate.vim, which in turn calls vim's built-in glob() function. Well, I discovered that glob() doesn't actually do the globbing itself; it uses the current shell to do that -- and that's the problem: Different shells accept slightly different patterns and apparently, zsh (which is what I use) chokes on the pattern `/home/me/.vim/snippets/tex/end\{so.snippet` (notice that the curly brace _is_ escaped!) or something; whatever it is, it causes glob() to return this file as a match although it doesn't exist!

The solution I came up with is to filter the list that glob() returns using filereadable(); while this probably is not the best solution, it's a passable workaround and it fixes the bug for me.

NB: This may also fix garbas/vim-snipmate#53.
