### PR TITLE
Added protection on DefaultPool for regular expressions in triggers

### DIFF
--- a/autoload/snipMate.vim
+++ b/autoload/snipMate.vim
@@ -650,7 +650,7 @@ fun! snipMate#DefaultPool(scopes, trigger, result)
 	for [f,opts] in items(snipMate#GetSnippetFiles(1, a:scopes, a:trigger))
 		if opts.type == 'snippets'
 			for [trigger, name, contents, guard] in cached_file_contents#CachedFileContents(f, s:c.read_snippets_cached, 0)
-				if trigger !~ triggerR | continue | endif
+				if trigger !~ '\V'.triggerR | continue | endif
 				if snipMate#EvalGuard(guard)
 					call snipMate#SetByPath(a:result, [trigger, opts.name_prefix.' '.name], contents)
 				endif


### PR DESCRIPTION
For example, if triggerR contains a tilde, one can get a
'No previous substitute regular expression' error.

Example:
In a tex file, I had "Eq.~\ref{", and if I try to push tab (also working with SuperTab) I would get a 'No previous substitute regular expression' error.
