### PR TITLE
Custom backwards key gets extra bracket

### DIFF
--- a/after/plugin/snipMate.vim
+++ b/after/plugin/snipMate.vim
@@ -15,13 +15,13 @@ if !exists('g:snips_trigger_key')
 endif
 
 if !exists('g:snips_trigger_key_backwards')
-  let g:snips_trigger_key_backwards = '<s-' . substitute(g:snips_trigger_key, '[<>]', '', 'g')
+  let g:snips_trigger_key_backwards = '<s-' . substitute(g:snips_trigger_key, '[<>]', '', 'g') . '>'
 endif
 
 exec 'ino <silent> ' . g:snips_trigger_key . ' <c-g>u<c-r>=snipMate#TriggerSnippet()<cr>'
 exec 'snor <silent> ' . g:snips_trigger_key . ' <esc>i<right><c-r>=snipMate#TriggerSnippet()<cr>'
-exec 'ino <silent> ' . g:snips_trigger_key_backwards . '> <c-r>=snipMate#BackwardsSnippet()<cr>'
-exec 'snor <silent> ' . g:snips_trigger_key_backwards . '> <esc>i<right><c-r>=snipMate#BackwardsSnippet()<cr>'
+exec 'ino <silent> ' . g:snips_trigger_key_backwards . ' <c-r>=snipMate#BackwardsSnippet()<cr>'
+exec 'snor <silent> ' . g:snips_trigger_key_backwards . ' <esc>i<right><c-r>=snipMate#BackwardsSnippet()<cr>'
 exec 'ino <silent> <c-r>' . g:snips_trigger_key . ' <c-r>=snipMate#ShowAvailableSnips()<cr>'
 
 " maybe there is a better way without polluting registers ?


### PR DESCRIPTION
When setting a custom backwards key with `let g:snips_trigger_key_backwards = foobar` there's an extra `>` added to the mapping.

The lines in question that add this can be found in the file `after/plugin/snipMate.vim`:

```
exec 'ino <silent> ' . g:snips_trigger_key_backwards . '> <c-r>=snipMate#BackwardsSnippet()<cr>'
exec 'snor <silent> ' . g:snips_trigger_key_backwards . '> <esc>i<right><c-r>=snipMate#BackwardsSnippet()<cr>'
```

I suspect that this extra `>` is added due to the automatic attempt to add a "shift-reverse-binding" with the lines right above:

```
if !exists('g:snips_trigger_key_backwards')
  let g:snips_trigger_key_backwards = '<s-' . substitute(g:snips_trigger_key, '[<>]', '', 'g')
endif
```

So I guess it works when the variable is not set, since a `<s-` is prepended, but if the variable is set then the extra `>` breaks things.
