### PR TITLE
Unexpected errors related to glob method, when no snippet is found

### DIFF
--- a/autoload/snipMate.vim
+++ b/autoload/snipMate.vim
@@ -571,8 +571,13 @@ fun! s:Glob(dir,  file)
 		" leads to glob() sometimes returning files that don't
 		" exist, so filter the returned list to make sure that the
 		" files really exist in the filesystem.
-		let res = glob(escape(f,"{}"), 0, 1)
-		return filter(res, 'filereadable(v:val)')
+		let res = split(glob(escape(f,"{}")), "\n")
+
+		if !empty(res)
+			return filter(res, 'filereadable(v:val)')
+		else
+			return []
+		endif
 	else
 		return filereadable(f) ? [f] : []
 	endif


### PR DESCRIPTION
There is a problem with a previous pull request: https://github.com/garbas/vim-snipmate/pull/91/files

When no snippet is found, the following errors are thrown:

`Error detected while processing function snipMate#ShowAvailableSnips..snipMate#GetSnippetsForWordBelowCursor..funcref#Call..snipMate#GetSnippets..funcref#Call..snipMate#DefaultPool..snipMate#GetSnippetFiles..<SNR>49_Glob:
line    9:
E118: Too many arguments for function: glob
Error detected while processing function snipMate#ShowAvailableSnips..snipMate#GetSnippetsForWordBelowCursor..funcref#Call..snipMate#GetSnippets..funcref#Call..snipMate#DefaultPool..snipMate#GetSnippetFiles..<SNR>49_Glob:
line    9:
E15: Invalid expression: glob(escape(f,"{}"), 0, 1)
Error detected while processing function snipMate#ShowAvailableSnips..snipMate#GetSnippetsForWordBelowCursor..funcref#Call..snipMate#GetSnippets..funcref#Call..snipMate#DefaultPool..snipMate#GetSnippetFiles..<SNR>49_Glob:
line   10:
E121: Undefined variable: res`

Hopefully this should fix it.
