### PR TITLE
Fix disappearing variables bug

### DIFF
--- a/autoload/snipMate.vim
+++ b/autoload/snipMate.vim
@@ -324,9 +324,7 @@ function! s:state_proto.update_changes()
 	let col = col('.')
 	if line('.') != self.cur_stop[0] || col < self.start_col || col > self.end_col
 		call self.remove()
-	endif
-
-	if self.has_vars
+	elseif self.has_vars
 		call self.update_vars(change_len)
 	endif
 


### PR DESCRIPTION
This appears to fix a bug where all variables would be cleared when
exiting insert mode then opening a line below the current line.

Having only just looked at the code, I am obviously not familiar with
its inner-workings, but this change seems to fix the bug I was
experiencing as described above.
