### PR TITLE
Fix variable typo in source code

### DIFF
--- a/ftplugin/snippet.vim
+++ b/ftplugin/snippet.vim
@@ -1,7 +1,7 @@
 command! -buffer -range=% RetabSnip <line1>,<line2>call snipMate#RetabSnip()
 vnoremap <buffer> <cr> :RetabSnip<cr>
 
-if !exists('g:nsippet_no_indentation_settings')
+if !exists('g:snippet_no_indentation_settings')
   setlocal sw=4
   setlocal tabstop=4
   setlocal noexpandtab


### PR DESCRIPTION
I found a small variable typo in source code. I like the project so I think it is worth contributing to show appreciation.
Thanks!
