### PR TITLE
Updates for snippet with normal for syntax

### DIFF
--- a/doc/SnipMate.txt
+++ b/doc/SnipMate.txt
@@ -250,7 +250,7 @@ the tab stop. This text then can be copied throughout the snippet using "$#",
 given # is the same number as used before. So, to make a C for loop: >
 
     snippet for
-        for (${2:i}; $2 < ${1:count}; $1++) {
+        for (${2:i}=0; $2 < ${1:count}; $2++) {
             ${4}
         }
 


### PR DESCRIPTION
Before this patch the for loop would have been

for(i; i < count; count++) {
  #...
}

This increments the control variable which isn't the norm so I thought it would be better served as:

for(i=0; i < count; i++) {
  #...
}

Amos King @adkron amos.l.king@gmail.com
