### PR TITLE
Fix bug while updating vars

### DIFF
--- a/autoload/snipMate.vim
+++ b/autoload/snipMate.vim
@@ -321,8 +321,9 @@ function! s:state_proto.update_changes()
 	let self.end_col += change_len
 
 	let col = col('.')
-	if mode() == 'i' && (line('.') != self.cur_stop[0]
-				\ || col < self.start_col || col > self.end_col)
+	if self.end_col < 0
+		\ || mode() == 'i' && (line('.') != self.cur_stop[0]
+		\ || col < self.start_col || col > self.end_col)
 		call self.remove()
 	elseif self.has_vars
 		call self.update_vars(change_len)


### PR DESCRIPTION
While I am writing javascript typing `for<tab><esc>kk`, the terrible thing happened:

``` js
 for (var i = 0, l = arr.length; i < l; i ++) {
   var v =   var v = [i];
 }
```

This PR can fix this problem.
