### PR TITLE
Add CSS scope alias for common css preprocessors

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -26,6 +26,7 @@ additional contributions from:
 * [jherdman](https://github.com/jherdman)
 * [kozo2](https://github.com/kozo2)
 * [lilydjwg](https://github.com/lilydjwg)
+* [lpil](https://github.com/lpil)
 * [marutanm](https://github.com/marutanm)
 * [MicahElliott](https://github.com/MicahElliott)
 * [muffinresearch](https://github.com/muffinresearch)

--- a/plugin/snipMate.vim
+++ b/plugin/snipMate.vim
@@ -81,6 +81,10 @@ if (!exists('g:snipMate_no_default_aliases') || !g:snipMate_no_default_aliases)
 				\ get(g:snipMate.scope_aliases, 'mxml', 'actionscript')
 	let g:snipMate.scope_aliases.eruby =
 				\ get(g:snipMate.scope_aliases, 'eruby', 'eruby-rails,html')
+	let g:snipMate.scope_aliases.scss =
+				\ get(g:snipMate.scope_aliases, 'scss', 'css')
+	let g:snipMate.scope_aliases.less =
+				\ get(g:snipMate.scope_aliases, 'less', 'css')
 endif
 
 let g:snipMate['get_snippets'] = get(g:snipMate, 'get_snippets', funcref#Function("snipMate#GetSnippets"))


### PR DESCRIPTION
Hiya

CSS preprocessors (i.e. SCSS, LESS) use pretty much CSS syntax, so they would benefit from having a CSS scope alias.
These preprocessors are widely used (rails uses SCSS by default), so I think this would be beneficial.

Cheers,
Louis
