### PR TITLE
Alias mkd to markdown for plasticboy/vim-markdown

### DIFF
--- a/plugin/snipMate.vim
+++ b/plugin/snipMate.vim
@@ -81,6 +81,8 @@ if (!exists('g:snipMate_no_default_aliases') || !g:snipMate_no_default_aliases)
 				\ get(g:snipMate.scope_aliases, 'mxml', 'actionscript')
 	let g:snipMate.scope_aliases.eruby =
 				\ get(g:snipMate.scope_aliases, 'eruby', 'eruby-rails,html')
+	let g:snipMate.scope_aliases.mkd =
+				\ get(g:snipMate.scope_aliases, 'mkd', 'markdown')
 endif
 
 let g:snipMate['get_snippets'] = get(g:snipMate, 'get_snippets', funcref#Function("snipMate#GetSnippets"))


### PR DESCRIPTION
https://github.com/plasticboy/vim-markdown

They use `mkd`, and changing that would be backwards incompatible, so I'd rather avoid it.

Not sure if this should be done here or at: https://github.com/honza/vim-snippets/pull/482
