### PR TITLE
Update documentation (README.md)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,12 +39,12 @@ looking at the [vim-snippets][vim-snippets] repository.
 * Using [Vundle][vundle], add the following to your `vimrc` then run
   `:PluginInstall`
 
-        Plugin "MarcWeber/vim-addon-mw-utils"
-        Plugin "tomtom/tlib_vim"
-        Plugin "garbas/vim-snipmate"
+        Plugin 'MarcWeber/vim-addon-mw-utils'
+        Plugin 'tomtom/tlib_vim'
+        Plugin 'garbas/vim-snipmate'
 
         " Optional:
-        Plugin "honza/vim-snippets"
+        Plugin 'honza/vim-snippets'
 
 ## FAQ ##
 


### PR DESCRIPTION
Changed double quotation marks on lines 42-44 and 47 to single quotation
marks (double quotes don't seem to work with Vundle, at least not on my
system)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/garbas/vim-snipmate/204)
<!-- Reviewable:end -->
