### PR TITLE
Bug fix : When using substitution on mirrors

### DIFF
--- a/autoload/snipmate/jumping.vim
+++ b/autoload/snipmate/jumping.vim
@@ -113,7 +113,7 @@ function! s:state_update_changes() dict abort
 		return self.remove()
 	endif
 
-	call self.update(self.cur_stop, change_len)
+	call self.update(self.cur_stop, change_len, change_len)
 	if !empty(self.mirrors)
 		call self.update_mirrors(change_len)
 	endif
@@ -141,14 +141,37 @@ function! s:state_update_mirrors(change) dict abort
 			endif
 		endfor
 
-		call self.update(mirror, changeLen)
+		if has_key(mirror, 'oldSize')
+			" recover the old size deduce the endline
+			let oldSize = mirror.oldSize
+		else
+			" first time, we use the intitial size
+			let oldSize = strlen(newWord)
+		endif
+
 		" Split the line into three parts: the mirror, what's before it, and
 		" what's after it. Then combine them using the new mirror string.
 		" Subtract one to go from column index to byte index
+
 		let theline = getline(mirror.line)
-		let update  = strpart(theline, 0, mirror.col - 1)
-		let update .= substitute(newWord, get(mirror, 'pat', ''), get(mirror, 'sub', ''), get(mirror, 'flags', ''))
-		let update .= strpart(theline, mirror.col + self.end_col - self.start_col - a:change - 1)
+
+		" part before the current mirror
+		let beginline  = strpart(theline, 0, mirror.col - 1)
+
+		" current mirror transformation, and save size
+		let wordMirror= substitute(newWord, get(mirror, 'pat', ''), get(mirror, 'sub', ''), get(mirror, 'flags', ''))
+		let mirror.oldSize = strlen(wordMirror)
+
+		" end of the line, use the oldSize because with the transformation,
+		" the size of the mirror can be different from those of the snippet
+		let endline    = strpart(theline, mirror.col + oldSize -1)
+
+		" Update other object on the line
+		call self.update(mirror, changeLen, mirror.oldSize - oldSize)
+
+		" reconstruct the line
+		let update = beginline.wordMirror.endline
+
 		call setline(mirror.line, update)
 	endfor
 
@@ -179,7 +202,7 @@ function! s:state_find_update_objects(item) dict abort
 	return item.update_objects
 endfunction
 
-function! s:state_update(item, change_len) dict abort
+function! s:state_update(item, change_len, mirror_change) dict abort
 	let item = a:item
 	if exists('item.update_objects')
 		let to_update = item.update_objects
@@ -189,7 +212,9 @@ function! s:state_update(item, change_len) dict abort
 	endif
 
 	for obj in to_update
-		let obj.col += a:change_len
+		" object does not necessarly have the same decalage
+		" than mirrors if mirrors use regexp
+		let obj.col += a:mirror_change
 		if obj is self.cur_stop
 			let self.start_col += a:change_len
 			let self.end_col += a:change_len


### PR DESCRIPTION
With the new snippet engine it is possible to use substitution on snippet.

## Main snippet :
```
snippet get
        inline const ${2:auto} get${1/\\([a-zA-Z]*\\)\\(_*\\)/\\u\\1/g}(${3:void}) ${4:const}
        {
          return ${1:Var};
        }
```

## Exemple of the bug before correction :

on the previous snippet : 

inline const _auto_ get**Toto**(_void_) _const_
{
     return **toto\_**\<CURSOR\>;
}

then if tab is pressed : 

inline const **auto**\<CURSOR\> getTotovoid) _const_
{
     return _toto\__;
}

the left parenthese disapear because the right part of the line was calculated using the size of _toto\__ wich is one more than (get)**Toto**. The substitute remove the \_, we need to consider that to recover the end of the first line.

This pull request allow to have mirror with size different from the base object.

I have also updated things in order to have a consistent placeholder on object at the right of the mirror