### PR TITLE
Fix bugs with completion and non-standard bindings

### DIFF
--- a/autoload/snipMate.vim
+++ b/autoload/snipMate.vim
@@ -583,7 +583,22 @@ function! snipMate#TriggerSnippet(...) abort
 			call feedkeys(SuperTabKey) | return ''
 		endif
 		call feedkeys("\<esc>a", 'n') " Close completion menu
-		call feedkeys("\<tab>") | return ''
+		" Once we've dismissed the completion menu, we have to cause this
+		" function to be executed over again, so that we actually get the
+		" snippet triggered. (Simply continuing to execute fails because
+		" we have to finish this function before the results of feedkeys take
+		" effect and dismiss the completion menu. Recursing also fails for
+		" similar reasons.)
+		if a:0 == 0
+			" Would be nice to have a more robust solution than manually
+			" branching on the arguments. I tried to do something like:
+			" call call(function('snipMate#TriggerSnippet'), a:000)
+			" But I couldn't quite get it working. Maybe somebody else with
+			" better vimscript skills can find a way to make it work, though?
+			call feedkeys("\<Plug>snipMateNextOrTrigger") | return ''
+		else
+			call feedkeys("\<Plug>snipMateTrigger") | return ''
+		endif
 	endif
 
 	if exists('b:snip_state') && a:0 == 0 " Jump only if no arguments


### PR DESCRIPTION
If the completion menu is visible and the user triggers a snippet command, the menu is normally dismissed so that the snippet command can execute. In order to do this, SnipMate uses `feedkeys` to dismiss the menu, then also uses `feedkeys` so that the snippet function gets called again after the menu is closed.

However, in the current SnipMate code, this second part is accomplished via a call to `feedkeys("\<tab>")`, which only works if we're using the default SnipMate bindings. If a non-standard key binding is used, then the snippet fails to trigger.

(This is perhaps less of an issue when the user has more direct control over the completion menu, but it renders SnipMate basically unusable when it's combined with a plugin like YouCompleteMe where the completion menu appears automatically as you type.)

This change also fixes a possible issue where `feedkeys("\<tab>")` might have triggered `snipMateNextOrTrigger` even if the original command the user had intended to execute might have been `snipMateTrigger`.