### PR TITLE
adds support for snippet comments in completion text

### DIFF
--- a/doc/SnipMate.txt
+++ b/doc/SnipMate.txt
@@ -168,6 +168,21 @@ g:snipMate.always_choose_first
                                 Always choose first snippet if there are
                                 multiple left
 
+g:snipMate.comment_in_completion
+                                If set to 1 (default is 0), snippet comment will
+                                be included in the popup menu used for snippet
+                                completion, like with <Plug>snipMateShow. A
+                                comment can be set by adding a line, which
+                                starts with a #, right before the line, which
+                                starts with snippet.
+
+g:snipMate.comment_in_completion_max_length
+                                This variable is only used if
+                                comment_in_completion is set to 1. This variable
+                                expects an Integer. It cuts comment strings,
+                                shown in the completion menu, at the given max
+                                length.
+
 g:snipMate.description_in_completion
                                 If set to 1 (default is 0), snippet
                                 descriptions will be included in the popup


### PR DESCRIPTION
This little change adds comments support. The basic idea is, to have a really small snippet abbreviation as snippet trigger and a comment that describes the snippet further.

An example:

```
# xml schema element with complexType and simple content                                                              
snippet xsect                                              
    <xs:element name="${1}">                                                         
        <xs:complexType>                                                             
            <xs:simpleContent>                                                       
                <xs:extension base="${2}">                                           
                    ${0}                                                          
                </xs:extension>                                                      
            </xs:simpleContent>                                                      
        </xs:complexType>                                                            
    </xs:element> 
```

autocomplete menu shows:

`xsect      xml schema element with complexType and simple content `
