### PR TITLE
fix: dont highlight space indentation as error

### DIFF
--- a/syntax/snippets.vim
+++ b/syntax/snippets.vim
@@ -10,7 +10,7 @@ syn match snippet '^extends.*' contains=snipKeyword
 syn match snippet '^version.*' contains=snipKeyword
 syn match multiSnipText '\S\+ \zs.*' contained
 syn match snipKeyword '^(snippet|extends|version)'me=s+8 contained
-syn match snipError "^[^#vse\t].*$"
+syn match snipError "^[^#vse\t ].*$"
 
 hi link snippet       Identifier
 hi link snipComment   Comment


### PR DESCRIPTION
Currently only TAB char was acceptable as a syntax compliant, this commits adds a space char too.

This allows non-TAB users to not be bothered by the error highlight

ps: For some reason \s seems to not work here so added a pure space instead of \s