### PR TITLE
Fix SnipMate-Selections for older versions of Vim

### DIFF
--- a/autoload/snipmate/jumping.vim
+++ b/autoload/snipmate/jumping.vim
@@ -243,7 +243,7 @@ endfunction
 " selection hack in s:state_select_item
 function! s:cot_count()
 	let cotl = split(&cot, ',')
-	let c = count(cotl, 'longest') + count(cotl, 'noinsert') + count(cotl, 'noselect')
+	let c = (has('patch-9.0.0567') && count(cotl, 'longest')) + count(cotl, 'noinsert') + count(cotl, 'noselect')
 	return min([1, c])
 endfunction
 


### PR DESCRIPTION
As described in issue #304, this problem still exists in older versions of Vim. The reason is due to the `longest` option, please refer to the [changes](https://github.com/vim/vim/commit/87af60c91503e37c9144f8e48022b12994ce2c85#diff-9a8ec83c488c52752fb97b6e82eb814e99f327f55e5005186d18bdf6f1bbcd2eR2895-R2903) of Vim Patch 9.0.0567. The problem can be reproduced by compiling patch 9.0.0567 and patch 9.0.0566 separately then `set completeopt+=longest`, I have compiled and tested it.